### PR TITLE
카카오 및 네이버 회원가입/로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,14 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //JWT 토큰 의존성
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/drive_only/drive_only_server/config/AppConfig.java
+++ b/src/main/java/drive_only/drive_only_server/config/AppConfig.java
@@ -1,0 +1,15 @@
+package drive_only.drive_only_server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+//RestTemplate을 Bean으로 등록
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/config/SecurityConfig.java
+++ b/src/main/java/drive_only/drive_only_server/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+    package drive_only.drive_only_server.config;
+
+    import drive_only.drive_only_server.security.JwtAuthenticationFilter;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.context.annotation.Configuration;
+    import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+    import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+    import org.springframework.context.annotation.Bean;
+    import org.springframework.security.config.http.SessionCreationPolicy;
+    import org.springframework.security.web.SecurityFilterChain;
+    import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+    import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+    @Configuration
+    @EnableWebSecurity
+    @RequiredArgsConstructor
+    public class SecurityConfig {
+        private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            return http
+                    //JWT 방식이기 때문에 세션 기반 CSRF 보호가 필요하지 않아 꺼줌
+                    .csrf(AbstractHttpConfigurer::disable)
+                    //세션을 아예 만들지 않도록 JWT 토큰 인증은 서버 세션을 사용하지 않음
+                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    //api/login 경로는 누구나 접근 허용
+                    .authorizeHttpRequests(auth -> auth
+                            .requestMatchers("/api/login/**").permitAll()
+                            .anyRequest().authenticated()
+                    )
+                    //사용자 로그인 폼 인증 전에 JWT 필터를 실행 클라이언트가 보낸 JWT 토큰을 검증
+                    .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                    //SecurityFilterChain 객체를 생성
+                    .build();
+        }
+    }
+

--- a/src/main/java/drive_only/drive_only_server/controller/auth/AuthController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/auth/AuthController.java
@@ -1,0 +1,57 @@
+package drive_only.drive_only_server.controller.auth;
+
+import drive_only.drive_only_server.domain.Member;
+import drive_only.drive_only_server.dto.auth.SocialLoginRequest;
+import drive_only.drive_only_server.dto.auth.TokenResponse;
+import drive_only.drive_only_server.dto.oauth.OAuthUserInfo;
+import drive_only.drive_only_server.security.JwtTokenProvider;
+import drive_only.drive_only_server.service.Member.MemberService;
+import drive_only.drive_only_server.service.oauth.OAuth2UserInfoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/login")
+public class AuthController {
+
+    private final OAuth2UserInfoService oAuth2UserInfoService;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/kakao")
+    public ResponseEntity<TokenResponse> kakaoLogin(@RequestBody SocialLoginRequest request) {
+
+        // 카카오 인가코드 → access_token
+        // 카카오 access_token → 사용자 정보
+        OAuthUserInfo userInfo = oAuth2UserInfoService.kakaoLogin(request.getCode(), request.getRedirectUri());
+
+        // 회원가입/로그인
+        Member member = memberService.registerOrLogin(userInfo);
+
+        // 우리 서버 JWT 발급
+        String jwt = jwtTokenProvider.createToken(member.getEmail(), member.getProvider());
+
+        return ResponseEntity.ok(new TokenResponse(jwt));
+    }
+
+    @PostMapping("/naver")
+    public ResponseEntity<TokenResponse> naverLogin(@RequestBody SocialLoginRequest request) {
+
+        // 네이버 인가코드 → access_token
+        // 네이버 access_token → 사용자 정보
+        OAuthUserInfo userInfo = oAuth2UserInfoService.naverLogin(request.getCode(), request.getRedirectUri());
+
+        // 회원가입/로그인
+        Member member = memberService.registerOrLogin(userInfo);
+
+        // 우리 서버 JWT 발급
+        String jwt = jwtTokenProvider.createToken(member.getEmail(), member.getProvider());
+
+        return ResponseEntity.ok(new TokenResponse(jwt));
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/domain/Comment.java
+++ b/src/main/java/drive_only/drive_only_server/domain/Comment.java
@@ -65,4 +65,6 @@ public class Comment {
         this.childComments.add(child);
         child.parentComment = this;
     }
+
+    public void setMember(Member member) { this.member = member; } //Member 연관 관계 편의 메소드 때문에 만들었음
 }

--- a/src/main/java/drive_only/drive_only_server/domain/Member.java
+++ b/src/main/java/drive_only/drive_only_server/domain/Member.java
@@ -8,12 +8,15 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = @UniqueConstraint(columnNames = {"email", "provider"})
+)
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "email")
+    @Column(name = "email", nullable = false) // 소셜 로그인의 식별자는 이메일
     private String email;
 
     @Column(name = "nickname")
@@ -22,16 +25,32 @@ public class Member {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
-    @Column(name = "provider")
-    private String provider;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false)
+    private ProviderType provider;
 
     @OneToMany(mappedBy = "member", orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
-    public Member(String email, String nickname, String profileImageUrl, String provider) {
-        this.email = email;
-        this.nickname = nickname;
-        this.profileImageUrl = profileImageUrl;
-        this.provider = provider;
+    // 정적 팩토리 메서드 (여기서 필드 세팅)
+    public static Member createMember(String email, String nickname, String profileImageUrl, ProviderType provider) {
+        Member member = new Member();
+        member.email = email;
+        member.nickname = nickname;
+        member.profileImageUrl = profileImageUrl;
+        member.provider = provider;
+        return member;
     }
+
+    // 연관 관계 편의 메서드
+    public void addComment(Comment comment) {
+        comments.add(comment);
+        comment.setMember(this);
+    }
+
+    public void removeComment(Comment comment) {
+        comments.remove(comment);
+        comment.setMember(null);
+    }
+
 }

--- a/src/main/java/drive_only/drive_only_server/domain/ProviderType.java
+++ b/src/main/java/drive_only/drive_only_server/domain/ProviderType.java
@@ -1,0 +1,6 @@
+package drive_only.drive_only_server.domain;
+
+public enum ProviderType {
+    KAKAO,
+    NAVER
+}

--- a/src/main/java/drive_only/drive_only_server/dto/auth/SocialLoginRequest.java
+++ b/src/main/java/drive_only/drive_only_server/dto/auth/SocialLoginRequest.java
@@ -1,0 +1,11 @@
+package drive_only.drive_only_server.dto.auth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SocialLoginRequest {
+    private String code; // 인가코드
+    private String redirectUri; // 클라이언트에서 사용한 redirectUri
+}

--- a/src/main/java/drive_only/drive_only_server/dto/auth/TokenResponse.java
+++ b/src/main/java/drive_only/drive_only_server/dto/auth/TokenResponse.java
@@ -1,0 +1,10 @@
+package drive_only.drive_only_server.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/drive_only/drive_only_server/dto/oauth/KakaoTokenResponse.java
+++ b/src/main/java/drive_only/drive_only_server/dto/oauth/KakaoTokenResponse.java
@@ -1,0 +1,14 @@
+package drive_only.drive_only_server.dto.oauth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private String scope;
+}

--- a/src/main/java/drive_only/drive_only_server/dto/oauth/OAuthUserInfo.java
+++ b/src/main/java/drive_only/drive_only_server/dto/oauth/OAuthUserInfo.java
@@ -1,0 +1,16 @@
+package drive_only.drive_only_server.dto.oauth;
+
+import drive_only.drive_only_server.domain.ProviderType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OAuthUserInfo {
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+    private ProviderType provider;
+}

--- a/src/main/java/drive_only/drive_only_server/repository/MemberRepository.java
+++ b/src/main/java/drive_only/drive_only_server/repository/MemberRepository.java
@@ -1,9 +1,13 @@
 package drive_only.drive_only_server.repository;
 
 import drive_only.drive_only_server.domain.Member;
+import drive_only.drive_only_server.domain.ProviderType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmailAndProvider(String email, ProviderType provider);
 }

--- a/src/main/java/drive_only/drive_only_server/security/JwtAuthenticationFilter.java
+++ b/src/main/java/drive_only/drive_only_server/security/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package drive_only.drive_only_server.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+//OncePerRequestFilter 요청당 한 번만 실행
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+        System.out.println("JWT Filter path: " + path); //TODO : path 확인용 추후 삭제
+        // 로그인 요청은 필터 통과
+        if (path.startsWith("/api/login")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        // 헤더가 없거나 형식이 잘못되면 통과 (다음 필터로)
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Bearer 토큰에서 실제 토큰 값 추출
+        String token = authorizationHeader.substring(7);
+
+        if (jwtTokenProvider.validateToken(token)) {
+            // 유효한 토큰이면 이메일, provider 추출
+            String email = jwtTokenProvider.getEmail(token);
+            String provider = jwtTokenProvider.getProvider(token);
+
+            // 인증 객체 생성
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            email,
+                            null,
+                            List.of() // SimpleGrantedAuthority 추가 가능
+                    );
+
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            // SecurityContext에 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        // 다음 필터로 전달
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/security/JwtTokenProvider.java
+++ b/src/main/java/drive_only/drive_only_server/security/JwtTokenProvider.java
@@ -1,0 +1,63 @@
+package drive_only.drive_only_server.security;
+
+import drive_only.drive_only_server.domain.ProviderType;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import io.jsonwebtoken.Claims;
+
+import io.jsonwebtoken.security.SignatureException;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret-key}")
+    private String SECRET_KEY;
+
+    @Value("${jwt.expiration}")
+    private long EXPIRATION;
+
+    //토큰 생성
+    public String createToken(String email, ProviderType provider) {
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("provider", provider.name())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+    }
+
+    //토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
+            return true;
+        } catch (SignatureException | ExpiredJwtException e) {
+            return false;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    //토큰에서 email 추출
+    public String getEmail(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    //토큰에서 provider 추출 (Optional)
+    public String getProvider(String token) {
+        return (String) getClaims(token).get("provider");
+    }
+
+    //공통 claims 파싱 메서드
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(SECRET_KEY)
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/service/Member/MemberService.java
+++ b/src/main/java/drive_only/drive_only_server/service/Member/MemberService.java
@@ -1,0 +1,27 @@
+package drive_only.drive_only_server.service.Member;
+
+import drive_only.drive_only_server.domain.Member;
+import drive_only.drive_only_server.dto.oauth.OAuthUserInfo;
+import drive_only.drive_only_server.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member registerOrLogin(OAuthUserInfo userInfo) {
+        return memberRepository.findByEmailAndProvider(userInfo.getEmail(), userInfo.getProvider())
+                .orElseGet(() -> {
+                    Member newMember = Member.createMember(
+                            userInfo.getEmail(),
+                            userInfo.getNickname(),
+                            userInfo.getProfileImageUrl(),
+                            userInfo.getProvider()
+                    );
+                    return memberRepository.save(newMember);
+                });
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/service/comment/CommentService.java
+++ b/src/main/java/drive_only/drive_only_server/service/comment/CommentService.java
@@ -3,6 +3,7 @@ package drive_only.drive_only_server.service.comment;
 import drive_only.drive_only_server.domain.Comment;
 import drive_only.drive_only_server.domain.Course;
 import drive_only.drive_only_server.domain.Member;
+import drive_only.drive_only_server.domain.ProviderType;
 import drive_only.drive_only_server.dto.comment.create.CommentCreateRequest;
 import drive_only.drive_only_server.dto.comment.create.CommentCreateResponse;
 import drive_only.drive_only_server.dto.comment.search.CommentListResponse;
@@ -28,7 +29,7 @@ public class CommentService {
     public CommentCreateResponse createComment(Long courseId, CommentCreateRequest request) {
         Course course = findCourse(courseId);
         //TODO : 나중에 멤버 관련 기능들이 완성되면 리팩토링
-        Member member = new Member("test", "test", "test", "test");
+        Member member = Member.createMember("email", "nickname", "profile", ProviderType.KAKAO);
         memberRepository.save(member);
         Comment comment = new Comment(request.content(), member, course, null);
 
@@ -44,7 +45,7 @@ public class CommentService {
     public CommentListResponse searchComments(Long courseId, int page, int size) {
         Course course = findCourse(courseId);
         //TODO : 나중에 멤버 관련 기능들이 완성되면 현재 로그인 된 멤버로 리팩토링
-        Member member = new Member("test", "test", "test", "test");
+        Member member = Member.createMember("email", "nickname", "profile", ProviderType.KAKAO);
         List<Comment> comments = course.getComments().stream()
                 .filter(comment -> comment.getParentComment() == null && !comment.isDeleted())
                 .toList();

--- a/src/main/java/drive_only/drive_only_server/service/course/CourseService.java
+++ b/src/main/java/drive_only/drive_only_server/service/course/CourseService.java
@@ -1,12 +1,6 @@
 package drive_only.drive_only_server.service.course;
 
-import drive_only.drive_only_server.domain.Category;
-import drive_only.drive_only_server.domain.Course;
-import drive_only.drive_only_server.domain.CoursePlace;
-import drive_only.drive_only_server.domain.Member;
-import drive_only.drive_only_server.domain.Photo;
-import drive_only.drive_only_server.domain.Place;
-import drive_only.drive_only_server.domain.Tag;
+import drive_only.drive_only_server.domain.*;
 import drive_only.drive_only_server.dto.category.CategoryResponse;
 import drive_only.drive_only_server.dto.course.create.CourseCreateRequest;
 import drive_only.drive_only_server.dto.course.create.CourseCreateResponse;
@@ -137,7 +131,12 @@ public class CourseService {
     }
 
     private Member createMember() {
-        Member mockMember = new Member("email", "nickname", "url", "provider");
+        Member mockMember = Member.createMember(
+                "email",
+                "nickname",
+                "url",
+                ProviderType.KAKAO
+        );
         memberRepository.save(mockMember);
         return mockMember;
     }

--- a/src/main/java/drive_only/drive_only_server/service/oauth/OAuth2UserInfoService.java
+++ b/src/main/java/drive_only/drive_only_server/service/oauth/OAuth2UserInfoService.java
@@ -1,0 +1,138 @@
+package drive_only.drive_only_server.service.oauth;
+
+import drive_only.drive_only_server.domain.ProviderType;
+import drive_only.drive_only_server.dto.oauth.KakaoTokenResponse;
+import drive_only.drive_only_server.dto.oauth.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2UserInfoService {
+
+    private final RestTemplate restTemplate;
+
+    // 카카오
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${kakao.token-uri}")
+    private String kakaoTokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String kakaoUserInfoUri;
+
+    // 네이버
+    @Value("${naver.client-id}")
+    private String naverClientId;
+
+    @Value("${naver.client-secret}")
+    private String naverClientSecret;
+
+    @Value("${naver.token-uri}")
+    private String naverTokenUri;
+
+    @Value("${naver.user-info-uri}")
+    private String naverUserInfoUri;
+
+    // ===================== 카카오 =====================
+    public OAuthUserInfo kakaoLogin(String code, String redirectUri) {
+        String accessToken = exchangeCodeForAccessToken(
+                code, redirectUri,
+                kakaoClientId, kakaoClientSecret,
+                kakaoTokenUri
+        );
+        return getKakaoUserInfo(accessToken);
+    }
+
+    private OAuthUserInfo getKakaoUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                kakaoUserInfoUri,
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) ((Map)response.getBody().get("kakao_account"));
+        String email = (String) kakaoAccount.get("email");
+        String nickname = (String) ((Map) kakaoAccount.get("profile")).get("nickname");
+        String profileImage = (String) ((Map) kakaoAccount.get("profile")).get("profile_image_url");
+
+        return new OAuthUserInfo(email, nickname, profileImage, ProviderType.KAKAO);
+    }
+
+    // ===================== 네이버 =====================
+    public OAuthUserInfo naverLogin(String code, String redirectUri) {
+        String accessToken = exchangeCodeForAccessToken(
+                code, redirectUri,
+                naverClientId, naverClientSecret,
+                naverTokenUri
+        );
+        return getNaverUserInfo(accessToken);
+    }
+
+    private OAuthUserInfo getNaverUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                naverUserInfoUri,
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        Map<String, Object> responseBody = (Map) response.getBody().get("response");
+        String email = (String) responseBody.get("email");
+        String nickname = (String) responseBody.get("nickname");
+        String profileImage = (String) responseBody.get("profile_image");
+
+        return new OAuthUserInfo(email, nickname, profileImage, ProviderType.NAVER);
+    }
+
+    // ===================== 공통 토큰 교환 =====================
+    private String exchangeCodeForAccessToken(
+            String code,
+            String redirectUri,
+            String clientId,
+            String clientSecret,
+            String tokenUri
+    ) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                tokenUri,
+                request,
+                Map.class
+        );
+
+        return (String) response.getBody().get("access_token");
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈번호
> "close #이슈번호" 형태로 작성
- close #38 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)
- JWT 기반 로그인 및 인증 필터 구현
- Secret Key 생성 및 설정 과정

## 💬 리뷰 요구사항(상의할 내용)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-Member의 provider String에서 Enum으로 변경
-CommentService / CourseService의 생성자 부분 생성 메서드 형식으로 변경
-accessToken 받아오는 방식을 서버 주도 방식으로 변경
