### PR TITLE
[FEAT] Redis Blacklist 활용한 로그아웃 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
     //Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    //Reids
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/drive_only/drive_only_server/config/RedisConfig.java
+++ b/src/main/java/drive_only/drive_only_server/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package drive_only.drive_only_server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    //스프링이 Redis 서버와의 연결을 관리하게 함
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    //스프링 데이터에서 Redis 명령을 쉽게 수행할 수 있게 도와주는 템플릿
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/config/SecurityConfig.java
+++ b/src/main/java/drive_only/drive_only_server/config/SecurityConfig.java
@@ -27,7 +27,7 @@
                     //api/login 경로는 누구나 접근 허용
                     .authorizeHttpRequests(auth -> auth
                             // TODO : 프론트 페이지 경로 나오고 수정 하기
-                            .requestMatchers("/api/login/**", "**").permitAll()
+                            .requestMatchers("/api/login/**", "/api/logout/**").permitAll()
                             .anyRequest().authenticated()
                     )
                     //사용자 로그인 폼 인증 전에 JWT 필터를 실행 클라이언트가 보낸 JWT 토큰을 검증

--- a/src/main/java/drive_only/drive_only_server/controller/auth/LogoutController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/auth/LogoutController.java
@@ -1,0 +1,43 @@
+package drive_only.drive_only_server.controller.auth;
+
+import drive_only.drive_only_server.security.JwtTokenProvider;
+import drive_only.drive_only_server.service.auth.LogoutService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/logout")
+public class LogoutController {
+    private final LogoutService logoutService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        String token = authHeader.substring(7);
+        if (!jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        Date expiration = jwtTokenProvider.getExpirationDate(token);
+        long now = System.currentTimeMillis();
+        long remainingMillis = expiration.getTime() - now;
+
+        if (remainingMillis > 0) {
+            logoutService.blacklistToken(token, remainingMillis);
+        }
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/controller/auth/ProtectedTestController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/auth/ProtectedTestController.java
@@ -1,0 +1,17 @@
+package drive_only.drive_only_server.controller.auth;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+//AccessToken 유효한지 테스트 하는 컨트롤러
+@RestController
+@RequestMapping("/api")
+public class ProtectedTestController {
+
+    @GetMapping("/protected")
+    public ResponseEntity<String> protectedApi() {
+        return ResponseEntity.ok("You have accessed a protected resource!");
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/security/JwtAuthenticationFilter.java
+++ b/src/main/java/drive_only/drive_only_server/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package drive_only.drive_only_server.security;
 
+import drive_only.drive_only_server.service.auth.LogoutService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,6 +21,7 @@ import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final LogoutService logoutService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -46,6 +48,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = authorizationHeader.substring(7);
 
         if (jwtTokenProvider.validateToken(token)) {
+
+            // 블랙리스트 체크
+            if (logoutService.isBlacklisted(token)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+
             // 유효한 토큰이면 이메일, provider 추출
             String email = jwtTokenProvider.getEmail(token);
             String provider = jwtTokenProvider.getProvider(token);

--- a/src/main/java/drive_only/drive_only_server/security/JwtTokenProvider.java
+++ b/src/main/java/drive_only/drive_only_server/security/JwtTokenProvider.java
@@ -60,4 +60,9 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
     }
+
+    //만료일 추출 메서드
+    public Date getExpirationDate(String token) {
+        return getClaims(token).getExpiration();
+    }
 }

--- a/src/main/java/drive_only/drive_only_server/service/auth/LogoutService.java
+++ b/src/main/java/drive_only/drive_only_server/service/auth/LogoutService.java
@@ -1,0 +1,22 @@
+package drive_only.drive_only_server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    //expirationMillis → JWT 만료시간 - 현재시간 → 토큰과 똑같이 만료되도록 TTL 설정
+    public void blacklistToken(String token, long expirationMillis) {
+        redisTemplate.opsForValue().set(token, "blacklisted", expirationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    public boolean isBlacklisted(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(token));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈번호
> "close #이슈번호" 형태로 작성
- close #57

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)
- SecurityConfig 허용 경로 수정
- LogoutController 추가
- ProtectedTestController 추가
- JwtAuthenticationFilter에 블랙리스트 체크 로직 추가
- JwtTokenProvider에 만료일 추출 메서드 추가
- LogoutService 추가
- application.yml에 Reids 설정 추가

## 💬 리뷰 요구사항(상의할 내용)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 로컬에서만 테스트 했기 때문에 drive-only.com 버전으로 다시 테스트 해야 합니다
- SecurityConfig에 허용 경로를 로그인/로그아웃 페이지만 허용했기 때문에 merge 하시면 민준님이 작업하시는 페이지는 작동하지 않을 것입니다. 테스트 후 전체 페이지 허용으로 다시 바꿔 놓겠습니다.
- 로그아웃 테스트까지 완료하면 로그인 필요한 페이지에 민준님이 헤더의 JWT 토큰을 검증해서 유효한 사용자인지 체크하는 로직 추가하시면 될 것 같습니다!