### PR TITLE
[FEAT] Refresh Token 추가

### DIFF
--- a/src/main/java/drive_only/drive_only_server/config/RedisConfig.java
+++ b/src/main/java/drive_only/drive_only_server/config/RedisConfig.java
@@ -1,25 +1,38 @@
 package drive_only.drive_only_server.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @Configuration
+@EnableRedisRepositories
 public class RedisConfig {
 
-    //스프링이 Redis 서버와의 연결을 관리하게 함
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory();
+        return new LettuceConnectionFactory(redisHost, redisPort);
     }
 
-    //스프링 데이터에서 Redis 명령을 쉽게 수행할 수 있게 도와주는 템플릿
     @Bean
-    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+    public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
+        template.setConnectionFactory(redisConnectionFactory());
+
+        // 직렬화 설정 추가
+        template.setKeySerializer(new org.springframework.data.redis.serializer.StringRedisSerializer());
+        template.setValueSerializer(new org.springframework.data.redis.serializer.StringRedisSerializer());
+
         return template;
     }
+
 }

--- a/src/main/java/drive_only/drive_only_server/config/SecurityConfig.java
+++ b/src/main/java/drive_only/drive_only_server/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 //api/login 경로는 누구나 접근 허용
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/login", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/login", "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/courses/**", "/api/places", "/api/categories").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/drive_only/drive_only_server/controller/auth/LogoutController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/auth/LogoutController.java
@@ -2,13 +2,17 @@ package drive_only.drive_only_server.controller.auth;
 
 import drive_only.drive_only_server.security.JwtTokenProvider;
 import drive_only.drive_only_server.service.auth.LogoutService;
+import drive_only.drive_only_server.service.auth.RefreshTokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +26,7 @@ import java.util.Date;
 public class LogoutController {
     private final LogoutService logoutService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Operation(summary = "로그아웃", description = "로그아웃 요청")
     @ApiResponses({
@@ -32,7 +37,10 @@ public class LogoutController {
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
     @PostMapping("/api/logout")
-    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authHeader) {
+    public ResponseEntity<Void> logout(
+            @RequestHeader("Authorization") String authHeader,
+            @CookieValue(value = "refresh-token", required = false) String refreshToken
+    ) {
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             return ResponseEntity.badRequest().build();
         }
@@ -42,6 +50,7 @@ public class LogoutController {
             return ResponseEntity.badRequest().build();
         }
 
+        // Access token 블랙리스트 처리
         Date expiration = jwtTokenProvider.getExpirationDate(token);
         long now = System.currentTimeMillis();
         long remainingMillis = expiration.getTime() - now;
@@ -50,6 +59,23 @@ public class LogoutController {
             logoutService.blacklistToken(token, remainingMillis);
         }
 
-        return ResponseEntity.ok().build();
+        // Refresh token Redis에서 삭제
+        if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
+            String email = jwtTokenProvider.getEmail(refreshToken);
+            refreshTokenService.deleteRefreshToken(email);
+        }
+
+        // 클라이언트 쿠키도 제거
+        ResponseCookie deleteCookie = ResponseCookie.from("refresh-token", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+                .build();
     }
 }

--- a/src/main/java/drive_only/drive_only_server/controller/auth/TokenRefreshController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/auth/TokenRefreshController.java
@@ -1,0 +1,62 @@
+package drive_only.drive_only_server.controller.auth;
+
+import drive_only.drive_only_server.domain.Member;
+import drive_only.drive_only_server.domain.ProviderType;
+import drive_only.drive_only_server.dto.auth.TokenResponse;
+import drive_only.drive_only_server.security.JwtTokenProvider;
+import drive_only.drive_only_server.service.Member.MemberService;
+import drive_only.drive_only_server.service.auth.RefreshTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenRefreshController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final MemberService memberService;
+
+    @Operation(
+            summary = "Access Token 재발급",
+            description = """
+        저장된 Refresh Token을 기반으로 새로운 Access Token을 발급합니다.
+        
+        - 클라이언트는 요청 시 `refresh-token`이라는 이름의 **HttpOnly 쿠키**를 함께 전송해야 합니다.
+        - 쿠키에 담긴 Refresh Token이 유효하고 서버에 저장된 토큰과 일치하면 새로운 Access Token을 반환합니다.
+        - 만료되었거나 위조된 경우 `401 Unauthorized`를 반환합니다.
+        """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Access Token 재발급 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않거나 일치하지 않는 Refresh Token", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @PostMapping("/api/auth/refresh")
+    public ResponseEntity<?> refreshAccessToken(@CookieValue(value = "refresh-token", required = false) String refreshToken) {
+        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh token이 유효하지 않음");
+        }
+
+        String email = jwtTokenProvider.getEmail(refreshToken);
+        String savedToken = refreshTokenService.getRefreshToken(email);
+
+        if (savedToken == null || !savedToken.equals(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh token 불일치 또는 만료");
+        }
+
+        // 💡 provider는 refresh token에서 가져오지 말고 DB에서 가져오자
+        Member member = memberService.findByEmail(email);
+        ProviderType provider = member.getProvider();
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(email, provider);
+        return ResponseEntity.ok().body(new TokenResponse(newAccessToken));
+    }
+}
+

--- a/src/main/java/drive_only/drive_only_server/security/JwtTokenProvider.java
+++ b/src/main/java/drive_only/drive_only_server/security/JwtTokenProvider.java
@@ -1,14 +1,11 @@
 package drive_only.drive_only_server.security;
 
 import drive_only.drive_only_server.domain.ProviderType;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import org.springframework.stereotype.Component;
-import org.springframework.beans.factory.annotation.Value;
-import io.jsonwebtoken.Claims;
-
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SignatureException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import java.util.Date;
 
 @Component
@@ -17,43 +14,34 @@ public class JwtTokenProvider {
     @Value("${jwt.secret-key}")
     private String SECRET_KEY;
 
-    @Value("${jwt.expiration}")
-    private long EXPIRATION;
+    @Value("${jwt.expiration}") // access token 만료시간 (ms)
+    private long ACCESS_TOKEN_EXPIRATION;
 
-    //토큰 생성
-    public String createToken(String email, ProviderType provider) {
+    @Value("${jwt.refresh-expiration}") // refresh token 만료시간 (ms)
+    private long REFRESH_TOKEN_EXPIRATION;
+
+    // Access Token 생성
+    public String createAccessToken(String email, ProviderType provider) {
         return Jwts.builder()
                 .setSubject(email)
                 .claim("provider", provider.name())
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
                 .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
                 .compact();
     }
 
-    //토큰 유효성 검사
-    public boolean validateToken(String token) {
-        try {
-            Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
-            return true;
-        } catch (SignatureException | ExpiredJwtException e) {
-            return false;
-        } catch (Exception e) {
-            return false;
-        }
+    // Refresh Token 생성
+    public String createRefreshToken(String email) {
+        return Jwts.builder()
+                .setSubject(email) // 사용자 식별
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
     }
 
-    //토큰에서 email 추출
-    public String getEmail(String token) {
-        return getClaims(token).getSubject();
-    }
-
-    //토큰에서 provider 추출 (Optional)
-    public String getProvider(String token) {
-        return (String) getClaims(token).get("provider");
-    }
-
-    //공통 claims 파싱 메서드
+    // 공통 Claims 파싱
     private Claims getClaims(String token) {
         return Jwts.parser()
                 .setSigningKey(SECRET_KEY)
@@ -61,7 +49,27 @@ public class JwtTokenProvider {
                 .getBody();
     }
 
-    //만료일 추출 메서드
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
+            return true;
+        } catch (SignatureException | ExpiredJwtException | MalformedJwtException e) {
+            return false;
+        }
+    }
+
+    // 토큰에서 이메일 추출
+    public String getEmail(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    // 토큰에서 provider 추출 (Access token 전용)
+    public String getProvider(String token) {
+        return (String) getClaims(token).get("provider");
+    }
+
+    // 만료일 추출
     public Date getExpirationDate(String token) {
         return getClaims(token).getExpiration();
     }

--- a/src/main/java/drive_only/drive_only_server/service/auth/RefreshTokenService.java
+++ b/src/main/java/drive_only/drive_only_server/service/auth/RefreshTokenService.java
@@ -1,0 +1,30 @@
+package drive_only.drive_only_server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String PREFIX = "refresh:";
+
+    // Redis에 저장
+    public void saveRefreshToken(String email, String token, long durationMillis) {
+        redisTemplate.opsForValue().set(PREFIX + email, token, durationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    // Redis에서 가져오기
+    public String getRefreshToken(String email) {
+        return redisTemplate.opsForValue().get(PREFIX + email);
+    }
+
+    // Redis에서 삭제
+    public void deleteRefreshToken(String email) {
+        redisTemplate.delete(PREFIX + email);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈번호
> "close #이슈번호" 형태로 작성
- close #89

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)
- JwtProvider 클래스에 createRefreshToken(), validateToken() 등 관련 메서드 추가
- 로그인 API에서 Refresh Token도 함께 발급하고 HttpOnly 쿠키로 응답에 포함
- /auth/refresh API 구현 (쿠키의 Refresh Token을 검증 → 새 Access Token 반환)
- Redis에 Refresh Token 저장 및 유효성 검증 로직 구현
- 로그아웃 API에서 Refresh Token 무효화 처리 (예: Redis 삭제)

## 💬 리뷰 요구사항(상의할 내용)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 토큰 유효기간 : AccessToken 30분 / RefreshToekn 7일로 설정했습니다!
