### PR TITLE
[FEAT] 신고 관련 API 작성

### DIFF
--- a/src/main/java/drive_only/drive_only_server/controller/comment/CommentController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/comment/CommentController.java
@@ -11,6 +11,7 @@ import drive_only.drive_only_server.dto.common.ApiResult;
 import drive_only.drive_only_server.dto.common.ApiResultSupport;
 import drive_only.drive_only_server.dto.common.PaginatedResponse;
 import drive_only.drive_only_server.dto.like.comment.CommentLikeResponse;
+import drive_only.drive_only_server.dto.report.ReportResponse;
 import drive_only.drive_only_server.exception.annotation.ApiErrorCodeExamples;
 import drive_only.drive_only_server.exception.errorcode.ErrorCode;
 import drive_only.drive_only_server.security.LoginMemberProvider;
@@ -128,4 +129,33 @@ public class CommentController {
         );
     }
 
+    @Operation(summary = "댓글/대댓글 신고(숨김)", description = "해당 댓글을 신고하여 신고자 본인 화면에서만 숨깁니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "신규 숨김 적용"),
+            @ApiResponse(responseCode = "200", description = "이미 숨김 상태(멱등)"),
+            @ApiResponse(responseCode = "404", description = "해당 댓글을 찾을 수 없음", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PostMapping("/api/comments/{commentId}/report")
+    public ResponseEntity<ApiResult<ReportResponse>> reportComment(@PathVariable Long commentId) {
+        ReportResponse result = commentService.reportComment(commentId);
+        SuccessCode sc = result.created()
+                ? SuccessCode.SUCCESS_REPORT_COMMENT_CREATED
+                : SuccessCode.SUCCESS_REPORT_COMMENT_ALREADY;
+        return ApiResultSupport.ok(sc, result);
+    }
+
+    @Operation(summary = "댓글/대댓글 신고(숨김) 해제", description = "신고자 본인 화면에서 숨긴 댓글을 다시 보이도록 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "숨김 해제(또는 이미 해제 상태)"),
+            @ApiResponse(responseCode = "404", description = "해당 댓글을 찾을 수 없음", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @DeleteMapping("/api/comments/{commentId}/report")
+    public ResponseEntity<ApiResult<ReportResponse>> unreportComment(@PathVariable Long commentId) {
+        ReportResponse result = commentService.unreportComment(commentId);
+        return ApiResultSupport.ok(SuccessCode.SUCCESS_UNREPORT_COMMENT, result);
+    }
 }

--- a/src/main/java/drive_only/drive_only_server/controller/course/CourseController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/course/CourseController.java
@@ -13,6 +13,7 @@ import drive_only.drive_only_server.dto.course.search.CourseSearchRequest;
 import drive_only.drive_only_server.dto.course.search.CourseSearchResponse;
 import drive_only.drive_only_server.dto.coursePlace.update.CoursePlaceUpdateResponse;
 import drive_only.drive_only_server.dto.like.course.CourseLikeResponse;
+import drive_only.drive_only_server.dto.report.ReportResponse;
 import drive_only.drive_only_server.exception.annotation.ApiErrorCodeExamples;
 import drive_only.drive_only_server.exception.errorcode.ErrorCode;
 import drive_only.drive_only_server.security.LoginMemberProvider;
@@ -157,5 +158,35 @@ public class CourseController {
                 status,
                 result
         );
+    }
+
+    @Operation(summary = "코스(게시글) 신고(숨김)", description = "해당 게시글을 신고하여 신고자 본인 화면에서만 숨깁니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "신규 숨김 적용"),
+            @ApiResponse(responseCode = "200", description = "이미 숨김 상태(멱등)"),
+            @ApiResponse(responseCode = "404", description = "해당 코스(게시글)을 찾을 수 없음", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PostMapping("/api/courses/{courseId}/report")
+    public ResponseEntity<ApiResult<ReportResponse>> reportCourse(@PathVariable Long courseId) {
+        ReportResponse result = courseService.reportCourse(courseId);
+        SuccessCode sc = result.created()
+                ? SuccessCode.SUCCESS_REPORT_COURSE_CREATED
+                : SuccessCode.SUCCESS_REPORT_COURSE_ALREADY;
+        return ApiResultSupport.ok(sc, result); // 상태코드는 sc.getStatus()로 자동 적용
+    }
+
+    @Operation(summary = "코스(게시글) 신고(숨김) 해제", description = "신고자 본인 화면에서 숨긴 게시글을 다시 보이도록 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "숨김 해제(또는 이미 해제 상태)"),
+            @ApiResponse(responseCode = "404", description = "해당 코스(게시글)을 찾을 수 없음", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @DeleteMapping("/api/courses/{courseId}/report")
+    public ResponseEntity<ApiResult<ReportResponse>> unreportCourse(@PathVariable Long courseId) {
+        ReportResponse result = courseService.unreportCourse(courseId);
+        return ApiResultSupport.ok(SuccessCode.SUCCESS_UNREPORT_COURSE, result);
     }
 }

--- a/src/main/java/drive_only/drive_only_server/domain/HiddenComment.java
+++ b/src/main/java/drive_only/drive_only_server/domain/HiddenComment.java
@@ -1,0 +1,30 @@
+package drive_only.drive_only_server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "hidden_comment",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id","comment_id"}))
+public class HiddenComment {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public HiddenComment(Member member, Comment comment) {
+        this.member = member;
+        this.comment = comment;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/domain/HiddenCourse.java
+++ b/src/main/java/drive_only/drive_only_server/domain/HiddenCourse.java
@@ -1,0 +1,30 @@
+package drive_only.drive_only_server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "hidden_course",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id","course_id"}))
+public class HiddenCourse {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public HiddenCourse(Member member, Course course) {
+        this.member = member;
+        this.course = course;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/dto/comment/search/CommentSearchResponse.java
+++ b/src/main/java/drive_only/drive_only_server/dto/comment/search/CommentSearchResponse.java
@@ -44,4 +44,30 @@ public record CommentSearchResponse(
                 replies
         );
     }
+
+    // 신고자가 숨긴 대댓글을 제외하는 버전
+    public static CommentSearchResponse fromFiltered(Comment comment, Member loginMember, java.util.Set<Long> hiddenIds) {
+        boolean isMine = comment.getMember().equals(loginMember);
+        boolean isLiked = loginMember.getLikedComments().stream()
+                .anyMatch(likedComment -> likedComment.getComment().getId().equals(comment.getId()));
+
+        List<CommentSearchResponse> replies = comment.getChildComments().stream()
+                .filter(child -> !hiddenIds.contains(child.getId()))
+                .map(child -> CommentSearchResponse.fromFiltered(child, loginMember, hiddenIds))
+                .toList();
+
+        return new CommentSearchResponse(
+                comment.getId(),
+                comment.getMember().getId(),
+                comment.getMember().getProfileImageUrl(),
+                comment.getMember().getNickname(),
+                comment.getContent(),
+                comment.getCreatedDate(),
+                comment.getLikeCount(),
+                isMine,
+                isLiked,
+                comment.isDeleted(),
+                replies
+        );
+    }
 }

--- a/src/main/java/drive_only/drive_only_server/dto/report/ReportResponse.java
+++ b/src/main/java/drive_only/drive_only_server/dto/report/ReportResponse.java
@@ -1,0 +1,7 @@
+package drive_only.drive_only_server.dto.report;
+
+public record ReportResponse(
+        String message,
+        boolean hidden,   // 현재 상태: 숨김=true, 해제=false
+        boolean created   // 이번 요청으로 새로 생성되었으면 true (POST만 의미 있음)
+) {}

--- a/src/main/java/drive_only/drive_only_server/repository/comment/CommentRepository.java
+++ b/src/main/java/drive_only/drive_only_server/repository/comment/CommentRepository.java
@@ -8,5 +8,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
-    Page<Comment> findParentCommentsByCourseId(Long courseId, Pageable pageable);
+    // 기존 메서드는 Custom에서 대체하므로 아래 라인은 삭제 또는 사용 중지 권장
+    // Page<Comment> findParentCommentsByCourseId(Long courseId, Long viewerId, Pageable pageable);
 }

--- a/src/main/java/drive_only/drive_only_server/repository/comment/CommentRepositoryCustom.java
+++ b/src/main/java/drive_only/drive_only_server/repository/comment/CommentRepositoryCustom.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CommentRepositoryCustom {
-    Page<Comment> findParentCommentsByCourseId(Long courseId, Pageable pageable);
+    Page<Comment> findParentCommentsByCourseId(Long courseId, Long viewerId, Pageable pageable);
 }

--- a/src/main/java/drive_only/drive_only_server/repository/course/CourseRepository.java
+++ b/src/main/java/drive_only/drive_only_server/repository/course/CourseRepository.java
@@ -9,5 +9,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long>, CourseRepositoryCustom {
-    Page<Course> searchCourses(CourseSearchRequest request, Pageable pageable);
+    // 기존 메서드는 Custom에서 대체하므로 아래 라인은 삭제 또는 사용 중지 권장
+    //Page<Course> searchCourses(CourseSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/drive_only/drive_only_server/repository/course/CourseRepositoryCustom.java
+++ b/src/main/java/drive_only/drive_only_server/repository/course/CourseRepositoryCustom.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface CourseRepositoryCustom {
-    Page<Course> searchCourses(CourseSearchRequest request, Pageable pageable);
-
     List<Course> findCoursesByMember(Long memberId, Long lastId, int size);
+
+    Page<Course> searchCourses(CourseSearchRequest request, Pageable pageable, Long viewerId);
 }

--- a/src/main/java/drive_only/drive_only_server/repository/hide/HiddenCommentRepository.java
+++ b/src/main/java/drive_only/drive_only_server/repository/hide/HiddenCommentRepository.java
@@ -1,0 +1,17 @@
+package drive_only.drive_only_server.repository.hide;
+
+import drive_only.drive_only_server.domain.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+public interface HiddenCommentRepository extends JpaRepository<HiddenComment, Long> {
+    boolean existsByCommentAndMember(Comment comment, Member member);
+    void deleteByCommentAndMember(Comment comment, Member member);
+
+    @Query("select hc.comment.id from HiddenComment hc where hc.member.id = :memberId")
+    Set<Long> findHiddenCommentIdsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/drive_only/drive_only_server/repository/hide/HiddenCourseRepository.java
+++ b/src/main/java/drive_only/drive_only_server/repository/hide/HiddenCourseRepository.java
@@ -1,0 +1,11 @@
+package drive_only.drive_only_server.repository.hide;
+
+import drive_only.drive_only_server.domain.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HiddenCourseRepository extends JpaRepository<HiddenCourse, Long> {
+    boolean existsByCourseAndMember(Course course, Member member);
+    void deleteByCourseAndMember(Course course, Member member);
+}

--- a/src/main/java/drive_only/drive_only_server/success/SuccessCode.java
+++ b/src/main/java/drive_only/drive_only_server/success/SuccessCode.java
@@ -14,6 +14,9 @@ public enum SuccessCode {
     SUCCESS_UPDATE_COURSE(HttpStatus.OK, "게시글이 성공적으로 수정되었습니다."),
     SUCCESS_DELETE_COURSE(HttpStatus.OK, "게시글이 성공적으로 삭제되었습니다."),
     SUCCESS_TOGGLE_COURSE_LIKE(HttpStatus.OK, "게시글 좋아요 상태가 변경되었습니다."),
+    SUCCESS_REPORT_COURSE_CREATED(HttpStatus.CREATED, "게시글을 신고하여 숨김 처리했습니다."),
+    SUCCESS_REPORT_COURSE_ALREADY(HttpStatus.OK, "이미 숨김 처리된 게시글입니다."),
+    SUCCESS_UNREPORT_COURSE(HttpStatus.OK, "게시글 숨김을 해제했습니다."),
 
     // Comment
     SUCCESS_GET_COMMENTS(HttpStatus.OK, "댓글 목록을 불러오는 데 성공했습니다."),
@@ -21,6 +24,9 @@ public enum SuccessCode {
     SUCCESS_UPDATE_COMMENT(HttpStatus.OK, "댓글이 성공적으로 수정되었습니다."),
     SUCCESS_DELETE_COMMENT(HttpStatus.OK, "댓글이 성공적으로 삭제되었습니다."),
     SUCCESS_TOGGLE_COMMENT_LIKE(HttpStatus.OK, "댓글 좋아요 상태가 변경되었습니다."),
+    SUCCESS_REPORT_COMMENT_CREATED(HttpStatus.CREATED, "댓글을 신고하여 숨김 처리했습니다."),
+    SUCCESS_REPORT_COMMENT_ALREADY(HttpStatus.OK, "이미 숨김 처리된 댓글입니다."),
+    SUCCESS_UNREPORT_COMMENT(HttpStatus.OK, "댓글 숨김을 해제했습니다."),
 
     // Place
     SUCCESS_GET_PLACES(HttpStatus.OK, "장소 목록을 불러오는 데 성공했습니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈번호
> "close #이슈번호" 형태로 작성
- close #122 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)
- CommentController 수정
- CourseController 수정
- CommentService 수정
- CourseService 수정
- HiddenComment 도메인 추가
- HiddenCourse 도메인 추가
- CommentSearchResponse 수정
- ReportResponse 추가
- CommentRepository 수정
- CommentRepositoryCustom 수정
- CommentRepositoryImpl 수정
- CourseRepository 수정
- CourseRepositoryCustom 수정
- CourseRepositoryImpl 수정
- HiddenCommentRepository 추가
- HiddenCourseRepository 추가
- SuccessCode 수정

## 💬 리뷰 요구사항(상의할 내용)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- CourseRepositroyImpl과 CommentRepositoryImpl의 searchCourses와 searchComments 메서드에
viewerId라는 현재 로그인 한 아이디를 찾는 파라미터를 신고한 게시글과 댓글을 숨김처리 하기 위해서 추가 했습니다. 

기존 로직을 건들지 않고 추가하긴 했지만 민준님도 한 번 확인 부탁드립니다.
코스(게시글) 조회와 댓글 및 대댓글 조회 API는 정상 작동하는 것은 확인했습니다.

- 신고한 코스(게시글)과 댓글을 위한 hidden_course와 hidden_comment 테이블 추가 했습니다. 아래 SQL문 업데이트 부탁 드립니다!

-- 게시글 숨김
CREATE TABLE IF NOT EXISTS hidden_course (
                                             id         BIGINT NOT NULL AUTO_INCREMENT,
                                             member_id  BIGINT NOT NULL,
                                             course_id  BIGINT NOT NULL,
                                             created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                                             PRIMARY KEY (id),
                                             UNIQUE KEY uk_hidden_course_member_course (member_id, course_id),
                                             KEY idx_hidden_course_member (member_id),
                                             KEY idx_hidden_course_course (course_id),
                                             CONSTRAINT fk_hidden_course_member
                                                 FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
                                             CONSTRAINT fk_hidden_course_course
                                                 FOREIGN KEY (course_id) REFERENCES course(id) ON DELETE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

-- 댓글 숨김
CREATE TABLE IF NOT EXISTS hidden_comment (
                                              id         BIGINT NOT NULL AUTO_INCREMENT,
                                              member_id  BIGINT NOT NULL,
                                              comment_id BIGINT NOT NULL,
                                              created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                                              PRIMARY KEY (id),
                                              UNIQUE KEY uk_hidden_comment_member_comment (member_id, comment_id),
                                              KEY idx_hidden_comment_member (member_id),
                                              KEY idx_hidden_comment_comment (comment_id),
                                              CONSTRAINT fk_hidden_comment_member
                                                  FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
                                              CONSTRAINT fk_hidden_comment_comment
                                                  FOREIGN KEY (comment_id) REFERENCES `comment`(id) ON DELETE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
