### PR TITLE
[FIX] 마이페이지 조회 단건으로 변경 및 저장한 장소 조회 무한 스크롤로 변경

### DIFF
--- a/src/main/java/drive_only/drive_only_server/controller/member/MemberController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/member/MemberController.java
@@ -3,6 +3,8 @@ package drive_only.drive_only_server.controller.member;
 import drive_only.drive_only_server.dto.common.ApiResult;
 import drive_only.drive_only_server.dto.common.ApiResultSupport;
 import drive_only.drive_only_server.dto.common.PaginatedResponse;
+import drive_only.drive_only_server.dto.member.MyProfileResponse;
+import drive_only.drive_only_server.dto.place.list.SavedPlaceListResponse;
 import drive_only.drive_only_server.dto.place.myPlace.DeleteSavedPlaceResponse;
 import drive_only.drive_only_server.dto.place.myPlace.SavePlaceResponse;
 import drive_only.drive_only_server.dto.place.search.SavedPlaceSearchResponse;
@@ -52,8 +54,8 @@ public class MemberController {
             ErrorCode.INTERNAL_SERVER_ERROR
     })
     @GetMapping("/api/members/me")
-    public ResponseEntity<ApiResult<PaginatedResponse<MemberResponse>>> getMyProfile() {
-        PaginatedResponse<MemberResponse> result = memberService.getMyProfile();
+    public ResponseEntity<ApiResult<MyProfileResponse>> getMyProfile() {
+        MyProfileResponse result = memberService.getMyProfile();
         return ApiResultSupport.ok(SuccessCode.SUCCESS_GET_MY_PROFILE, result);
     }
 
@@ -69,8 +71,8 @@ public class MemberController {
             ErrorCode.INTERNAL_SERVER_ERROR
     })
     @GetMapping("/api/members/{id}")
-    public ResponseEntity<ApiResult<PaginatedResponse<OtherMemberResponse>>> getOtherMemberProfile(@PathVariable Long id) {
-        PaginatedResponse<OtherMemberResponse> result = memberService.findOtherMember(id);
+    public ResponseEntity<ApiResult<OtherMemberResponse>> getOtherMemberProfile(@PathVariable Long id) {
+        OtherMemberResponse result = memberService.findOtherMember(id);
         return ApiResultSupport.ok(SuccessCode.SUCCESS_GET_OTHER_MEMBER, result);
     }
 
@@ -85,10 +87,8 @@ public class MemberController {
             ErrorCode.INTERNAL_SERVER_ERROR
     })
     @PatchMapping("/api/members/me")
-    public ResponseEntity<ApiResult<PaginatedResponse<MemberResponse>>> updateMyProfile(
-            @RequestBody MemberUpdateRequest request
-    ) {
-        PaginatedResponse<MemberResponse> result = memberService.updateMember(request);
+    public ResponseEntity<ApiResult<MemberResponse>> updateMyProfile(@RequestBody MemberUpdateRequest request) {
+        MemberResponse result = memberService.updateMember(request);
         return ApiResultSupport.ok(SuccessCode.SUCCESS_UPDATE_MEMBER, result);
     }
 
@@ -150,7 +150,7 @@ public class MemberController {
         );
     }
 
-    @Operation(summary = "좋아요한 코스 조회", description = "회원이 좋아요한 드라이브 코스를 최신순으로 조회")
+    @Operation(summary = "좋아요 한 코스 조회", description = "회원이 좋아요한 드라이브 코스를 최신순으로 조회")
     @ApiErrorCodeExamples({
             ErrorCode.MEMBER_NOT_FOUND,
             ErrorCode.ACCESS_TOKEN_EMPTY_ERROR,
@@ -195,8 +195,11 @@ public class MemberController {
             ErrorCode.INTERNAL_SERVER_ERROR
     })
     @GetMapping("/api/members/me/saved-places")
-    public ResponseEntity<ApiResult<PaginatedResponse<SavedPlaceSearchResponse>>> getSavedPlaces() {
-        PaginatedResponse<SavedPlaceSearchResponse> result = memberService.searchSavedPlaces();
+    public ResponseEntity<ApiResult<SavedPlaceListResponse>> getSavedPlaces(
+            @RequestParam(required = false) Long lastId,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        SavedPlaceListResponse result = memberService.searchSavedPlaces(lastId, size);
         return ApiResultSupport.ok(SuccessCode.SUCCESS_GET_SAVED_PLACES, result);
     }
 

--- a/src/main/java/drive_only/drive_only_server/dto/member/MyProfileResponse.java
+++ b/src/main/java/drive_only/drive_only_server/dto/member/MyProfileResponse.java
@@ -1,0 +1,9 @@
+package drive_only.drive_only_server.dto.member;
+
+public record MyProfileResponse(
+        Long id,
+        String email,
+        String nickname,
+        String profileImageUrl,
+        drive_only.drive_only_server.domain.ProviderType provider
+) {}

--- a/src/main/java/drive_only/drive_only_server/dto/place/list/SavedPlaceListResponse.java
+++ b/src/main/java/drive_only/drive_only_server/dto/place/list/SavedPlaceListResponse.java
@@ -1,0 +1,16 @@
+package drive_only.drive_only_server.dto.place.list;
+
+import drive_only.drive_only_server.dto.place.search.SavedPlaceSearchResponse;
+import java.util.List;
+
+
+public record SavedPlaceListResponse(
+        List<SavedPlaceSearchResponse> items,
+        Long lastId,
+        int size,
+        boolean hasNext
+) {
+    public static SavedPlaceListResponse from(List<SavedPlaceSearchResponse> items, Long lastId, int size, boolean hasNext) {
+        return new SavedPlaceListResponse(items, lastId, size, hasNext);
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/repository/course/SavedPlaceRepository.java
+++ b/src/main/java/drive_only/drive_only_server/repository/course/SavedPlaceRepository.java
@@ -1,14 +1,9 @@
 package drive_only.drive_only_server.repository.course;
 
-import drive_only.drive_only_server.domain.Member;
 import drive_only.drive_only_server.domain.SavedPlace;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SavedPlaceRepository extends JpaRepository<SavedPlace, Long> {
-    @Query("select sp from SavedPlace sp join fetch sp.place where sp.member = :member")
-    List<SavedPlace> findByMember(Member member);
+public interface SavedPlaceRepository extends JpaRepository<SavedPlace, Long>, SavedPlaceRepositoryCustom {
 }

--- a/src/main/java/drive_only/drive_only_server/repository/course/SavedPlaceRepositoryCustom.java
+++ b/src/main/java/drive_only/drive_only_server/repository/course/SavedPlaceRepositoryCustom.java
@@ -1,0 +1,8 @@
+package drive_only.drive_only_server.repository.course;
+
+import drive_only.drive_only_server.domain.SavedPlace;
+import java.util.List;
+
+public interface SavedPlaceRepositoryCustom {
+    List<SavedPlace> findSavedPlacesByMember(Long memberId, Long lastId, int sizePlusOne);
+}

--- a/src/main/java/drive_only/drive_only_server/repository/course/SavedPlaceRepositoryImpl.java
+++ b/src/main/java/drive_only/drive_only_server/repository/course/SavedPlaceRepositoryImpl.java
@@ -1,0 +1,32 @@
+package drive_only.drive_only_server.repository.course;
+
+import static drive_only.drive_only_server.domain.QSavedPlace.savedPlace;
+import static drive_only.drive_only_server.domain.QPlace.place;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import drive_only.drive_only_server.domain.SavedPlace;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+
+public class SavedPlaceRepositoryImpl implements SavedPlaceRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public SavedPlaceRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<SavedPlace> findSavedPlacesByMember(Long memberId, Long lastId, int sizePlusOne) {
+        return queryFactory
+                .selectFrom(savedPlace)
+                .join(savedPlace.place, place).fetchJoin()
+                .where(
+                        savedPlace.member.id.eq(memberId),
+                        lastId != null ? savedPlace.id.lt(lastId) : null
+                )
+                .orderBy(savedPlace.id.desc())
+                .limit(sizePlusOne)
+                .fetch();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈번호
> "close #이슈번호" 형태로 작성
- close #136 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)
- MemberController 수정
- MyProfileResponse 추가
- SavedPlaceListResponse 추가
- SavedPlaceRepository 추가
- SavedPlaceRepositoryCustom 추가
- SavedPlaceRepositoryImpl 추가
- MemberService 수정

## 💬 리뷰 요구사항(상의할 내용)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 좋아요 한 코스 조회, 작성한 코스 조회는 이미 무한 스크롤이라서
저장한 장소 리스트 조회만 변경 했는데 맞는지 확인 한 번만 해주세요!
