### PR TITLE
[FEAT] 운영자 로그인 추가

### DIFF
--- a/src/main/java/drive_only/drive_only_server/config/SecurityConfig.java
+++ b/src/main/java/drive_only/drive_only_server/config/SecurityConfig.java
@@ -14,6 +14,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import drive_only.drive_only_server.security.RestAccessDeniedHandler;
 import drive_only.drive_only_server.security.RestAuthenticationEntryPoint;
 import org.springframework.security.config.Customizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -31,7 +34,7 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers("/api/login", "/api/logout", "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/**").permitAll()
+                        .requestMatchers("/api/login", "/api/admin/login", "/api/logout", "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/courses/**", "/api/places/**", "/api/categories").permitAll()
                         .anyRequest().authenticated()
                 )
@@ -41,5 +44,10 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/drive_only/drive_only_server/controller/auth/AdminController.java
+++ b/src/main/java/drive_only/drive_only_server/controller/auth/AdminController.java
@@ -1,0 +1,99 @@
+package drive_only.drive_only_server.controller.auth;
+
+import drive_only.drive_only_server.domain.Member;
+import drive_only.drive_only_server.domain.ProviderType;
+import drive_only.drive_only_server.dto.auth.AdminLoginRequest;
+import drive_only.drive_only_server.dto.auth.AdminLoginResponse;
+import drive_only.drive_only_server.dto.common.ApiResult;
+import drive_only.drive_only_server.dto.common.ApiResultSupport;
+import drive_only.drive_only_server.exception.custom.BusinessException;
+import drive_only.drive_only_server.exception.errorcode.ErrorCode;
+import drive_only.drive_only_server.security.JwtTokenProvider;
+import drive_only.drive_only_server.service.auth.RefreshTokenService;
+import drive_only.drive_only_server.repository.member.MemberRepository; // MemberRepository 주입
+import drive_only.drive_only_server.success.SuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder; // PasswordEncoder 주입
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import drive_only.drive_only_server.exception.annotation.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+
+import java.time.Duration;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "운영자 로그인", description = "운영자 로그인 API")
+public class AdminController {
+
+    private final MemberRepository memberRepository; // MemberRepository 사용
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final PasswordEncoder passwordEncoder; // PasswordEncoder 주입
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshTokenExpiration; // ms 단위
+
+    @Operation(summary = "운영자 로그인", description = "ID/PW 기반 운영자 로그인 요청")
+    @ApiErrorCodeExamples({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.INVALID_PASSWORD,
+            ErrorCode.INTERNAL_SERVER_ERROR
+    })
+    @PostMapping("/api/admin/login")
+    public ResponseEntity<ApiResult<AdminLoginResponse>> adminLogin(@RequestBody AdminLoginRequest request) {
+
+        // 1. ID(이메일)로 회원 조회 (ProviderType.LOCAL 회원만)
+        Member admin = memberRepository.findByEmailAndProvider(request.getLoginId(), ProviderType.LOCAL)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. 비밀번호 확인
+        if (admin.getPassword() == null || !passwordEncoder.matches(request.getPassword(), admin.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // 3. 토큰 생성 (ProviderType.LOCAL 전달)
+        String accessToken = jwtTokenProvider.createAccessToken(admin.getEmail(), ProviderType.LOCAL);
+        String refreshToken = jwtTokenProvider.createRefreshToken(admin.getEmail(), ProviderType.LOCAL); // 리프레시 토큰에도 Provider 추가
+
+        // 4. refresh token Redis 저장
+        refreshTokenService.saveRefreshToken(admin.getEmail(), refreshToken, refreshTokenExpiration);
+
+        // 5. 쿠키 설정 (AuthController 로직 재사용)
+        ResponseCookie accessCookie = ResponseCookie.from("access-token", accessToken)
+                .httpOnly(true)
+                .secure(true)
+                .domain("drive-only.com")
+                .path("/")
+                .maxAge(Duration.ofMillis(jwtTokenProvider.getAccessTokenExpiration()))
+                .sameSite("None")
+                .build();
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh-token", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .domain("drive-only.com")
+                .path("/")
+                .maxAge(Duration.ofMillis(refreshTokenExpiration))
+                .sameSite("None")
+                .build();
+
+        // 6. 응답 본문 생성 (필요시 정보 추가)
+        AdminLoginResponse body = AdminLoginResponse.builder()
+                // .nickname(admin.getNickname())
+                .build();
+
+        // 7. 응답 반환
+        return ApiResultSupport.okWithCookies(
+                SuccessCode.SUCCESS_LOGIN, // 적절한 SuccessCode 정의 필요
+                body,
+                accessCookie,
+                refreshCookie
+        );
+    }
+}

--- a/src/main/java/drive_only/drive_only_server/domain/Member.java
+++ b/src/main/java/drive_only/drive_only_server/domain/Member.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Getter
@@ -38,6 +39,9 @@ public class Member {
     @Column(name = "provider", nullable = false)
     private ProviderType provider;
 
+    @Column(name = "password")
+    private String password;
+
     @OneToMany(mappedBy = "member", orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
@@ -60,6 +64,18 @@ public class Member {
         m.nickname = normalizeNullable(nickname);
         m.profileImageUrl = normalizeNullable(profileImageUrl);
         m.provider = provider;
+        return m;
+    }
+
+    public static Member createAdminMember(String email, String nickname, String password, PasswordEncoder passwordEncoder) {
+        validateEmail(email);
+        if (nickname != null) validateNickname(nickname);
+
+        Member m = new Member();
+        m.email = normalizeEmail(email);
+        m.nickname = normalizeNullable(nickname);
+        m.password = passwordEncoder.encode(password);
+        m.provider = ProviderType.LOCAL;
         return m;
     }
 

--- a/src/main/java/drive_only/drive_only_server/domain/ProviderType.java
+++ b/src/main/java/drive_only/drive_only_server/domain/ProviderType.java
@@ -2,5 +2,6 @@ package drive_only.drive_only_server.domain;
 
 public enum ProviderType {
     KAKAO,
-    NAVER
+    NAVER,
+    LOCAL
 }

--- a/src/main/java/drive_only/drive_only_server/dto/auth/AdminLoginRequest.java
+++ b/src/main/java/drive_only/drive_only_server/dto/auth/AdminLoginRequest.java
@@ -1,0 +1,11 @@
+package drive_only.drive_only_server.dto.auth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminLoginRequest {
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/drive_only/drive_only_server/dto/auth/AdminLoginResponse.java
+++ b/src/main/java/drive_only/drive_only_server/dto/auth/AdminLoginResponse.java
@@ -1,0 +1,11 @@
+package drive_only.drive_only_server.dto.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminLoginResponse {
+    // 필요시 운영자 정보 추가 (예: nickname)
+    // private String nickname;
+}

--- a/src/main/java/drive_only/drive_only_server/exception/errorcode/ErrorCode.java
+++ b/src/main/java/drive_only/drive_only_server/exception/errorcode/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     ALREADY_EXISTED_PLACE(HttpStatus.BAD_REQUEST, "이미 저장된 장소입니다."),
 
     //401 UNAUTHORIZED
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
     DUPLICATE_MEMBER(HttpStatus.CONFLICT, "이미 가입된 회원입니다."), // (선택) 동시가입 경합 구분용
     TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."), // (선택) 구분 필요 시,
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈번호
> "close #이슈번호" 형태로 작성
- close #140

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)
- Member 엔티티 수정
- ProviderType Enum 수정
- SecurityConfig 수정 (PasswordEncoder 추가 및 경로 허용)
- MemberRepository 수정
- 운영자 로그인 컨트롤러 및 DTO 생성
- JwtTokenProvider 및 Filter 수정 (ProviderType 처리)
- DB Member 테이블 수정

## 💬 리뷰 요구사항(상의할 내용)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- DB Member 테이블에 password 속성 추가 했습니다
- 기존 소셜 로그인에 문제 생기지 않게 작성했습니다 문제 생기면 알려주세요!
